### PR TITLE
Fixed output at end of script

### DIFF
--- a/install-bedrock-server.sh
+++ b/install-bedrock-server.sh
@@ -107,6 +107,7 @@ if ss -nlup | grep -q ":$port"; then
     echo
     echo "Please ensure that UDP port $port is also open in your security list/group."
     echo
-    echo "To interact with Minecraft Server command-line console run: \"sudo supervisorctl fg $server\""else
+    echo "To interact with Minecraft Server command-line console run: \"sudo supervisorctl fg $server\""
+else
     echo "Port $port UDP is not listening. Installation may have failed or the server is not running."
 fi

--- a/install-bedrock-server.sh
+++ b/install-bedrock-server.sh
@@ -14,7 +14,7 @@ if [ "$(id -u)" != "0" ]; then
 
 # Check if is Ubuntu or Debian Linux
 elif [ ! -f /etc/os-release ] || ( . /etc/os-release && [ "$ID" != "ubuntu" ] && [ "$ID" != "debian" ]); then
-    echo "This is unsupported OS. Minecraft Bedcrock Edition is only suported on Ubuntu or Debian"
+    echo "This is unsupported OS. Minecraft Bedrock Edition is only suported on Ubuntu or Debian"
     exit 1
 
 # Check if already installed


### PR DESCRIPTION
When the script finished, it was outputting both possible messages upon success, like so:

```
Installation completed. Your server is running and listening on UDP port 19132.

Please ensure that UDP port 19132 is also open in your security list/group.

To interact with Minecraft Server command-line console run: "sudo supervisorctl fg "else
Port 19132 UDP is not listening. Installation may have failed or the server is not running.
```
The script would output nothing if the port wasn't open.
Fixed this so that the correct message only shows depending on the result of the condition.
Also fixed a spelling mistake.